### PR TITLE
Remove redundant tag push trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,6 @@ name: Docker Image CI
 on:
   push:
     branches: [ "main", "stage" ]
-  
-  # Trigger workflow on tag push
-  push:
     tags:
       - v*.*.*
 


### PR DESCRIPTION
Eliminate the unnecessary tag push trigger from the CI workflow.